### PR TITLE
Fix import duplicates

### DIFF
--- a/db/migrate/20180122232509_change_credit_card_to_string.rb
+++ b/db/migrate/20180122232509_change_credit_card_to_string.rb
@@ -1,0 +1,5 @@
+class ChangeCreditCardToString < ActiveRecord::Migration[5.1]
+  def change
+    change_column :transactions, :credit_card_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180122224851) do
+ActiveRecord::Schema.define(version: 20180122225618) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,4 +22,57 @@ ActiveRecord::Schema.define(version: 20180122224851) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "invoice_items", force: :cascade do |t|
+    t.bigint "item_id"
+    t.bigint "invoice_id"
+    t.integer "quantity"
+    t.integer "unit_price"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["invoice_id"], name: "index_invoice_items_on_invoice_id"
+    t.index ["item_id"], name: "index_invoice_items_on_item_id"
+  end
+
+  create_table "invoices", force: :cascade do |t|
+    t.bigint "customer_id"
+    t.bigint "merchant_id"
+    t.integer "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_invoices_on_customer_id"
+    t.index ["merchant_id"], name: "index_invoices_on_merchant_id"
+  end
+
+  create_table "items", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.integer "unit_price"
+    t.bigint "merchant_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["merchant_id"], name: "index_items_on_merchant_id"
+  end
+
+  create_table "merchants", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "transactions", force: :cascade do |t|
+    t.bigint "invoice_id"
+    t.integer "credit_card_number"
+    t.string "credit_card_expiration_date"
+    t.integer "result"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["invoice_id"], name: "index_transactions_on_invoice_id"
+  end
+
+  add_foreign_key "invoice_items", "invoices"
+  add_foreign_key "invoice_items", "items"
+  add_foreign_key "invoices", "customers"
+  add_foreign_key "invoices", "merchants"
+  add_foreign_key "items", "merchants"
+  add_foreign_key "transactions", "invoices"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180122225618) do
+ActiveRecord::Schema.define(version: 20180122232509) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 20180122225618) do
 
   create_table "transactions", force: :cascade do |t|
     t.bigint "invoice_id"
-    t.integer "credit_card_number"
+    t.string "credit_card_number"
     t.string "credit_card_expiration_date"
     t.integer "result"
     t.datetime "created_at", null: false

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -17,6 +17,7 @@ namespace :import_csv do
                       created_at: row[:created_at],
                       updated_at: row[:updated_at])
     end
+    puts "Customers Loaded"
 
     CSV.foreach('data/merchants.csv', headers: true, header_converters: :symbol, converters: :numeric) do |row|
       Merchant.create!(id: row[:id],
@@ -24,6 +25,7 @@ namespace :import_csv do
         created_at: row[:created_at],
         updated_at: row[:updated_at])
       end
+    puts "Merchants Loaded"
 
     CSV.foreach('data/invoices.csv', headers: true, header_converters: :symbol, converters: :numeric) do |row|
       Invoice.create!(id: row[:id],
@@ -33,7 +35,7 @@ namespace :import_csv do
                       created_at: row[:created_at],
                       updated_at: row[:updated_at])
     end
-
+    puts "Invoices Loaded"
 
     CSV.foreach('data/items.csv', headers: true, header_converters: :symbol, converters: :numeric) do |row|
       Item.create!(id: row[:id],
@@ -44,6 +46,7 @@ namespace :import_csv do
                   created_at: row[:created_at],
                   updated_at: row[:updated_at])
     end
+    puts "Items Loaded"
 
     CSV.foreach('data/transactions.csv', headers: true, header_converters: :symbol, converters: :numeric) do |row|
       Transaction.create!(id: row[:id],
@@ -54,6 +57,7 @@ namespace :import_csv do
                           created_at: row[:created_at],
                           updated_at: row[:updated_at])
     end
+    puts "Transactions Loaded"
 
     CSV.foreach('data/invoice_items.csv', headers: true, header_converters: :symbol, converters: :numeric) do |row|
       InvoiceItem.create!(id: row[:id],
@@ -64,5 +68,6 @@ namespace :import_csv do
         created_at: row[:created_at],
         updated_at: row[:updated_at])
     end
+    puts "Invoice Items Loaded"
   end
 end

--- a/lib/tasks/import_csv.rake
+++ b/lib/tasks/import_csv.rake
@@ -3,6 +3,13 @@ require 'csv'
 namespace :import_csv do
   desc "Loads CSV into Database"
   task load: :environment do
+    InvoiceItem.all.each {|invoice_item| invoice_item.delete}
+    Transaction.all.each {|transaction| transaction.delete}
+    Item.all.each {|item| item.delete}
+    Invoice.all.each {|invoice| invoice.delete}
+    Customer.all.each {|customer| customer.delete}
+    Merchant.all.each {|merchant| merchant.delete}
+
     CSV.foreach('data/customers.csv', headers: true, header_converters: :symbol, converters: :numeric) do |row|
       Customer.create!(id: row[:id],
                       first_name: row[:first_name],


### PR DESCRIPTION
import_csv:load task now cleans database before importing and gives the user a status when objects are loaded.

Transaction credit card numbers are now strings instead of integers